### PR TITLE
Permit more recent universum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.11.0
+=====
+
+* Permit more recent versions of [universum](https://github.com/serokell/universum).
+  As result, `traceIdF` has less general type.
+
 0.10.0
 =====
 

--- a/serokell-util.cabal
+++ b/serokell-util.cabal
@@ -1,5 +1,5 @@
 name:                serokell-util
-version:             0.10.0.1
+version:             0.11.0
 synopsis:            General-purpose functions by Serokell
 homepage:            https://github.com/serokell/serokell-util
 license:             MIT
@@ -76,7 +76,7 @@ library
                      , text
                      , th-lift-instances
                      , transformers
-                     , universum >= 1.2.0
+                     , universum >= 1.2.0 && < 1.6
                      , unordered-containers >= 0.2.7.0
                      , vector
 
@@ -112,7 +112,7 @@ test-suite serokell-test
                      , quickcheck-instances
                      , scientific
                      , serokell-util
-                     , universum >= 1.2.0
+                     , universum >= 1.2.0 && < 1.6
                      , unordered-containers >= 0.2.7.0
                      , vector
   hs-source-dirs:      test

--- a/serokell-util.cabal
+++ b/serokell-util.cabal
@@ -1,5 +1,5 @@
 name:                serokell-util
-version:             0.10.0
+version:             0.10.0.1
 synopsis:            General-purpose functions by Serokell
 homepage:            https://github.com/serokell/serokell-util
 license:             MIT
@@ -76,7 +76,7 @@ library
                      , text
                      , th-lift-instances
                      , transformers
-                     , universum ^>= 1.2.0
+                     , universum >= 1.2.0
                      , unordered-containers >= 0.2.7.0
                      , vector
 
@@ -112,7 +112,7 @@ test-suite serokell-test
                      , quickcheck-instances
                      , scientific
                      , serokell-util
-                     , universum ^>= 1.2.0
+                     , universum >= 1.2.0
                      , unordered-containers >= 0.2.7.0
                      , vector
   hs-source-dirs:      test

--- a/src/Serokell/Util/Trace.hs
+++ b/src/Serokell/Util/Trace.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE UndecidableInstances   #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
@@ -10,18 +11,18 @@ module Serokell.Util.Trace
     ( traceIdF
     ) where
 
-import           Universum
+import Universum
 
-import           Data.Text           (Text)
-import           Formatting          (Format, now, sformat)
-import           Formatting.Internal (runFormat)
+import Data.Text (Text)
+import Formatting (Format, now, sformat)
+import Formatting.Internal (runFormat)
 
 -- | Class for supplying various variable-arguments traces
 class VarArgTrace fmt f | fmt -> f where
     traceIdFHelper :: fmt -> f
 
 instance {-# OVERLAPPING #-}
-         VarArgTrace (x -> Text) (x -> x) where
+         (p ~ Text) => VarArgTrace (x -> p) (x -> x) where
     traceIdFHelper fmt x = trace (fmt x) x
 
 instance VarArgTrace fmt f => VarArgTrace (a -> fmt) (a -> f) where

--- a/src/Serokell/Util/Trace.hs
+++ b/src/Serokell/Util/Trace.hs
@@ -21,7 +21,7 @@ class VarArgTrace fmt f | fmt -> f where
     traceIdFHelper :: fmt -> f
 
 instance {-# OVERLAPPING #-}
-         Print p => VarArgTrace (x -> p) (x -> x) where
+         VarArgTrace (x -> Text) (x -> x) where
     traceIdFHelper fmt x = trace (fmt x) x
 
 instance VarArgTrace fmt f => VarArgTrace (a -> fmt) (a -> f) where

--- a/src/Serokell/Util/Trace.hs
+++ b/src/Serokell/Util/Trace.hs
@@ -13,8 +13,8 @@ module Serokell.Util.Trace
 
 import           Universum
 
-import           Data.Text (Text)
-import           Formatting (Format, now, sformat)
+import           Data.Text           (Text)
+import           Formatting          (Format, now, sformat)
 import           Formatting.Internal (runFormat)
 
 -- | Class for supplying various variable-arguments traces

--- a/src/Serokell/Util/Trace.hs
+++ b/src/Serokell/Util/Trace.hs
@@ -11,11 +11,11 @@ module Serokell.Util.Trace
     ( traceIdF
     ) where
 
-import Universum
+import           Universum
 
-import Data.Text (Text)
-import Formatting (Format, now, sformat)
-import Formatting.Internal (runFormat)
+import           Data.Text (Text)
+import           Formatting (Format, now, sformat)
+import           Formatting.Internal (runFormat)
 
 -- | Class for supplying various variable-arguments traces
 class VarArgTrace fmt f | fmt -> f where


### PR DESCRIPTION
Problem: serokell-util requires that Universum is ^>= 1.2.0, i. e.
it is not compatible with 1.3.0, etc. However, it should work fine
with never Universum as well.
Solution: loosen the bounds.